### PR TITLE
only build images to us.gcr.io

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,43 +2,18 @@ timeout: 3600s
 steps:
 - id: certbot
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "gcr.io/$PROJECT_ID/certbot:latest", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/certbot:latest", "."]
   dir: .
   waitFor: ['-']
 
 - id: certbot-dns
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "gcr.io/$PROJECT_ID/certbot-dns-google:latest", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/certbot-dns-google:latest", "."]
   dir: certbot-dns-google
   waitFor:
     - certbot
-
-- id: us-certbot
-  name: 'gcr.io/cloud-builders/docker'
-  args: [
-    "build",
-    "-t", "us.gcr.io/$PROJECT_ID/certbot:latest",
-    "--cache-from", "gcr.io/$PROJECT_ID/certbot:latest",
-    "."]
-  dir: .
-  waitFor:
-    - certbot
-
-- id: us-certbot-dns
-  name: 'gcr.io/cloud-builders/docker'
-  args: [
-    "build",
-    "-t", "us.gcr.io/$PROJECT_ID/certbot-dns-google:latest",
-    "--cache-from", "gcr.io/$PROJECT_ID/certbot-dns-google:latest",
-    "."]
-  dir: certbot-dns-google
-  waitFor:
-    - certbot-dns
-    - us-certbot
 
 images:
-  - gcr.io/$PROJECT_ID/certbot
-  - gcr.io/$PROJECT_ID/certbot-dns-google
   - us.gcr.io/$PROJECT_ID/certbot
   - us.gcr.io/$PROJECT_ID/certbot-dns-google
 


### PR DESCRIPTION
**ASANA TASK LINK:**
https://app.asana.com/0/730608328772069/1132799849116039/f

**DESIGN DOC LINK:**
https://docs.google.com/document/d/1gox2x_WggIn4cUNirgjQdrmYehd-x6QMc6eE8EsZkH0/edit?folder=0B428sZA2e4WmdmxlSXNOSHozc2M#

DETAILS
-------
after references to gcr.io have been changed to us.gcr.io, stop building images to the gcr.io registry.

CHECK LIST
----------
**TEST PLAN:**

- [x] verify in cloud builder only us.gcr.io images are produced

**DID I MATERIALLY UPDATE DOCKERFILE(S)?:**
N

**ANY KNOWN IMPACT TO CUSTOMER SLAs?:**
N

**RISK & IMPACT ASSESSMENT:**
minimal risk